### PR TITLE
Dash Routing: Direct, Vnet_direct and Drop action support

### DIFF
--- a/dash-pipeline/Makefile
+++ b/dash-pipeline/Makefile
@@ -33,7 +33,9 @@ p4-clean:
 	-sudo rm -rf $(P4_ARTIFACTS)
 
 P4_SRC=bmv2/dash_pipeline.p4
-$(P4_ARTIFACTS):
+P4_ALL_SRC=$(wildcard bmv2/*.p4)
+
+$(P4_ARTIFACTS): $(P4_ALL_SRC)
 	@echo "Compile P4 program $(P4_SRC) ..."
 	docker run \
 	--rm --name p4c \
@@ -79,7 +81,7 @@ kill-switch:
 
 # TODO - create separate rules for headers, libsai.so
 .PHONY:sai
-sai: p4 | SAI/SAI 
+sai: p4 | SAI/SAI
 	@echo "Generate SAI library headers and implementation..."
 	$(DOCKER_RUN) \
 		--name build_sai-$(USER) \
@@ -90,7 +92,7 @@ sai: p4 | SAI/SAI
 	    make
 
 .PHONY:sai-clean
-sai-clean: SAI/SAI 
+sai-clean: SAI/SAI
 	@echo "Restoring SAI subdirectories to baseline..."
 	rm -rf SAI/SAI/inc SAI/SAI/experimental SAI/SAI/meta
 	cd SAI/SAI && git checkout -- inc experimental meta

--- a/dash-pipeline/bmv2/dash_metadata.p4
+++ b/dash-pipeline/bmv2/dash_metadata.p4
@@ -41,7 +41,9 @@ struct metadata_t {
     bit<16> inbound_vm_id;
     bit<8> appliance_id;
     bit<1> is_dst_ip_v6;
+    bit<1> is_lkup_dst_ip_v6;
     IPv4ORv6Address dst_ip_addr;
+    IPv4ORv6Address lkup_dst_ip_addr;
     conntrack_data_t conntrack_data;
 }
 

--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -223,8 +223,12 @@ control dash_ingress(inout headers_t hdr,
 
         eni_meter.apply();
 
-        /* Send packet to port 1 by default if we reached the end of pipeline */
-        standard_metadata.egress_spec = 1;
+        if (meta.dropped) {
+            drop_action();
+        } else {
+            /* Send packet to port 1 by default if we reached the end of pipeline */
+            standard_metadata.egress_spec = 1;
+        }
     }
 }
 


### PR DESCRIPTION
Support for remaining Phase 1 routing actions as specified in the Sonic HLD / Vnet-Vnet doc. 
It generates following additional SAI attributes.
```
/**
 * @brief Attribute data for #SAI_OUTBOUND_ROUTING_ENTRY_ATTR_ACTION
 */
typedef enum _sai_outbound_routing_entry_action_t
{
    SAI_OUTBOUND_ROUTING_ENTRY_ACTION_ROUTE_VNET,

    SAI_OUTBOUND_ROUTING_ENTRY_ACTION_ROUTE_DIRECT,

    SAI_OUTBOUND_ROUTING_ENTRY_ACTION_DROP,

} sai_outbound_routing_entry_action_t;

typedef enum _sai_outbound_routing_entry_attr_t
{
    SAI_OUTBOUND_ROUTING_ENTRY_ATTR_START,

    SAI_OUTBOUND_ROUTING_ENTRY_ATTR_ACTION = SAI_OUTBOUND_ROUTING_ENTRY_ATTR_START,

    SAI_OUTBOUND_ROUTING_ENTRY_ATTR_DEST_VNET_VNI,

    SAI_OUTBOUND_ROUTING_ENTRY_ATTR_USE_OVERLAY_NH_IP,

    SAI_OUTBOUND_ROUTING_ENTRY_ATTR_IS_OVERLAY_NH_IP_V6,

    SAI_OUTBOUND_ROUTING_ENTRY_ATTR_OVERLAY_NH_IP,

    SAI_OUTBOUND_ROUTING_ENTRY_ATTR_COUNTER_ID,

}

```